### PR TITLE
fix: remove unused generic param in onSuccess and onFailure

### DIFF
--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -134,13 +134,13 @@ extension AsyncResultExtension<S extends Object, F extends Object> //
   /// Performs the given action on the encapsulated Throwable
   /// exception if this instance represents failure.
   /// Returns the original Result unchanged.
-  AsyncResult<S, F> onFailure<W>(void Function(F failure) onFailure) {
+  AsyncResult<S, F> onFailure(void Function(F failure) onFailure) {
     return then((result) => result.onFailure(onFailure));
   }
 
   /// Performs the given action on the encapsulated value if this
   /// instance represents success. Returns the original Result unchanged.
-  AsyncResult<S, F> onSuccess<W>(void Function(S success) onSuccess) {
+  AsyncResult<S, F> onSuccess(void Function(S success) onSuccess) {
     return then((result) => result.onSuccess(onSuccess));
   }
 }

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -49,14 +49,14 @@ abstract class Result<S extends Object, F extends Object> {
 
   /// Performs the given action on the encapsulated value if this
   /// instance represents success. Returns the original Result unchanged.
-  Result<S, F> onSuccess<W>(
+  Result<S, F> onSuccess(
     void Function(S success) onSuccess,
   );
 
   /// Performs the given action on the encapsulated Throwable
   /// exception if this instance represents failure.
   /// Returns the original Result unchanged.
-  Result<S, F> onFailure<W>(
+  Result<S, F> onFailure(
     void Function(F failure) onFailure,
   );
 
@@ -211,12 +211,12 @@ class Success<S extends Object, F extends Object> implements Result<S, F> {
   AsyncResult<S, F> toAsyncResult() async => this;
 
   @override
-  Result<S, F> onFailure<W>(void Function(F failure) onFailure) {
+  Result<S, F> onFailure(void Function(F failure) onFailure) {
     return this;
   }
 
   @override
-  Result<S, F> onSuccess<W>(void Function(S success) onSuccess) {
+  Result<S, F> onSuccess(void Function(S success) onSuccess) {
     onSuccess(_success);
     return this;
   }
@@ -331,13 +331,13 @@ class Failure<S extends Object, F extends Object> implements Result<S, F> {
   AsyncResult<S, F> toAsyncResult() async => this;
 
   @override
-  Result<S, F> onFailure<W>(void Function(F failure) onFailure) {
+  Result<S, F> onFailure(void Function(F failure) onFailure) {
     onFailure(_failure);
     return this;
   }
 
   @override
-  Result<S, F> onSuccess<W>(void Function(S success) onSuccess) {
+  Result<S, F> onSuccess(void Function(S success) onSuccess) {
     return this;
   }
 }


### PR DESCRIPTION
I've noticed that the `W` generic parameter from the `onSuccess` and `onFailure` functions is not used.

The fact that it's the causes the linter to raise a warning:
<img width="758" alt="image" src="https://github.com/Flutterando/result_dart/assets/6546265/83ab86d5-6f05-49c1-83f2-44c975acc120">

This PR removes that generic parameter.

cc @jacobaraujo7
