### PR TITLE
Feature: support nullable Success value and generalise Failure type to Object

### DIFF
--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -10,7 +10,7 @@ extension AsyncResultDartExtension<S, F> //
     on AsyncResultDart<S, F> {
   /// Returns a new `Result`, mapping any `Success` value
   /// using the given transformation and unwrapping the produced `Result`.
-  AsyncResultDart<W, F> flatMap<W extends Object>(
+  AsyncResultDart<W, F> flatMap<W>(
     FutureOr<ResultDart<W, F>> Function(S success) fn,
   ) {
     return then((result) => result.fold(fn, Failure.new));
@@ -18,7 +18,7 @@ extension AsyncResultDartExtension<S, F> //
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  AsyncResultDart<S, W> flatMapError<W extends Object>(
+  AsyncResultDart<S, W> flatMapError<W>(
     FutureOr<ResultDart<S, W>> Function(F error) fn,
   ) {
     return then((result) => result.fold(Success.new, fn));

--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import '../result_dart.dart';
 
 /// `AsyncResultDart<S, E>` represents an asynchronous computation.
-typedef AsyncResultDart<S extends Object, F extends Object> = Future<ResultDart<S, F>>;
+typedef AsyncResultDart<S, F> = Future<ResultDart<S, F>>;
 
 /// `AsyncResultDart<S, E>` represents an asynchronous computation.
-extension AsyncResultDartExtension<S extends Object, F extends Object> //
+extension AsyncResultDartExtension<S, F> //
     on AsyncResultDart<S, F> {
   /// Returns a new `Result`, mapping any `Success` value
   /// using the given transformation and unwrapping the produced `Result`.
@@ -26,7 +26,7 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
 
   /// Returns a new `AsyncResultDart`, mapping any `Success` value
   /// using the given transformation.
-  AsyncResultDart<W, F> map<W extends Object>(
+  AsyncResultDart<W, F> map<W>(
     FutureOr<W> Function(S success) fn,
   ) {
     return then(
@@ -43,7 +43,7 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation.
-  AsyncResultDart<S, W> mapError<W extends Object>(
+  AsyncResultDart<S, W> mapError<W>(
     FutureOr<W> Function(F error) fn,
   ) {
     return then(
@@ -59,12 +59,12 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
   }
 
   /// Change a [Success] value.
-  AsyncResultDart<W, F> pure<W extends Object>(W success) {
+  AsyncResultDart<W, F> pure<W>(W success) {
     return then((result) => result.pure(success));
   }
 
   /// Change the [Failure] value.
-  AsyncResultDart<S, W> pureError<W extends Object>(W error) {
+  AsyncResultDart<S, W> pureError<W>(W error) {
     return mapError((_) => error);
   }
 
@@ -125,7 +125,7 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
   /// Returns the encapsulated `Result` of the given transform function
   /// applied to the encapsulated a `Failure` or the original
   /// encapsulated value if it is success.
-  AsyncResultDart<S, R> recover<R extends Object>(
+  AsyncResultDart<S, R> recover<R>(
     FutureOr<ResultDart<S, R>> Function(F failure) onFailure,
   ) {
     return then((result) => result.fold(Success.new, onFailure));
@@ -147,7 +147,7 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
   /// Returns the encapsulated value if this instance represents `Success`
   /// or the result of `onFailure` function for
   /// the encapsulated a `Failure` value.
-  AsyncResultDart<G, W> pureFold<G extends Object, W extends Object>(
+  AsyncResultDart<G, W> pureFold<G, W>(
     G success,
     W failure,
   ) {
@@ -157,7 +157,7 @@ extension AsyncResultDartExtension<S extends Object, F extends Object> //
   /// Returns the encapsulated value if this instance represents `Success`
   /// or the result of `onFailure` function for
   /// the encapsulated a `Failure` value.
-  AsyncResultDart<G, W> mapFold<G extends Object, W extends Object>(
+  AsyncResultDart<G, W> mapFold<G, W>(
     G Function(S success) onSuccess,
     W Function(F error) onError,
   ) {

--- a/lib/src/result_dart_base.dart
+++ b/lib/src/result_dart_base.dart
@@ -7,7 +7,7 @@ import 'unit.dart' as type_unit;
 ///
 /// Receives two values [F] and [S]
 /// as [F] is an error and [S] is a success.
-sealed class ResultDart<S extends Object, F extends Object> {
+sealed class ResultDart<S, F> {
   /// Returns the success value as a throwing expression.
   S getOrThrow();
 
@@ -55,29 +55,29 @@ sealed class ResultDart<S extends Object, F extends Object> {
 
   /// Returns a new `Result`, mapping any `Success` value
   /// using the given transformation.
-  ResultDart<W, F> map<W extends Object>(W Function(S success) fn);
+  ResultDart<W, F> map<W>(W Function(S success) fn);
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation.
-  ResultDart<S, W> mapError<W extends Object>(W Function(F error) fn);
+  ResultDart<S, W> mapError<W>(W Function(F error) fn);
 
   /// Returns a new `Result`, mapping any `Success` value
   /// using the given transformation and unwrapping the produced `Result`.
-  ResultDart<W, F> flatMap<W extends Object>(
+  ResultDart<W, F> flatMap<W>(
     ResultDart<W, F> Function(S success) fn,
   );
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  ResultDart<S, W> flatMapError<W extends Object>(
+  ResultDart<S, W> flatMapError<W>(
     ResultDart<S, W> Function(F error) fn,
   );
 
   /// Change the [Success] value.
-  ResultDart<W, F> pure<W extends Object>(W success);
+  ResultDart<W, F> pure<W>(W success);
 
   /// Change the [Failure] value.
-  ResultDart<S, W> pureError<W extends Object>(W error);
+  ResultDart<S, W> pureError<W>(W error);
 
   /// Return a [AsyncResult].
   AsyncResultDart<S, F> toAsyncResult();
@@ -89,7 +89,7 @@ sealed class ResultDart<S extends Object, F extends Object> {
   /// Returns the encapsulated `Result` of the given transform function
   /// applied to the encapsulated a `Failure` or the original
   /// encapsulated value if it is success.
-  ResultDart<S, R> recover<R extends Object>(
+  ResultDart<S, R> recover<R>(
     ResultDart<S, R> Function(F failure) onFailure,
   );
 
@@ -97,7 +97,7 @@ sealed class ResultDart<S extends Object, F extends Object> {
   /// using the given transformation and unwrapping the produced `Result`.
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  ResultDart<G, W> pureFold<G extends Object, W extends Object>(
+  ResultDart<G, W> pureFold<G, W>(
     G success,
     W failure,
   );
@@ -106,7 +106,7 @@ sealed class ResultDart<S extends Object, F extends Object> {
   /// using the given transformation and unwrapping the produced `Result`.
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  ResultDart<G, W> mapFold<G extends Object, W extends Object>(
+  ResultDart<G, W> mapFold<G, W>(
     G Function(S success) onSuccess,
     W Function(F failure) onFailure,
   );
@@ -117,7 +117,7 @@ sealed class ResultDart<S extends Object, F extends Object> {
 /// return it when the result of a [Result] is
 /// the expected value.
 @immutable
-final class Success<S extends Object, F extends Object> //
+final class Success<S, F> //
     implements
         ResultDart<S, F> {
   /// Receives the [S] param as
@@ -130,7 +130,7 @@ final class Success<S extends Object, F extends Object> //
   /// ```dart
   /// Success.unit() == Success(unit)
   /// ```
-  static Success<type_unit.Unit, F> unit<F extends Object>() {
+  static Success<type_unit.Unit, F> unit<F>() {
     return Success<type_unit.Unit, F>(type_unit.unit);
   }
 
@@ -165,14 +165,14 @@ final class Success<S extends Object, F extends Object> //
   S getOrNull() => _success;
 
   @override
-  ResultDart<W, F> flatMap<W extends Object>(
+  ResultDart<W, F> flatMap<W>(
     ResultDart<W, F> Function(S success) fn,
   ) {
     return fn(_success);
   }
 
   @override
-  ResultDart<S, W> flatMapError<W extends Object>(
+  ResultDart<S, W> flatMapError<W>(
     ResultDart<S, W> Function(F failure) fn,
   ) {
     return Success<S, W>(_success);
@@ -197,28 +197,28 @@ final class Success<S extends Object, F extends Object> //
   S getOrDefault(S defaultValue) => _success;
 
   @override
-  ResultDart<W, F> map<W extends Object>(W Function(S success) fn) {
+  ResultDart<W, F> map<W>(W Function(S success) fn) {
     final newSuccess = fn(_success);
     return Success<W, F>(newSuccess);
   }
 
   @override
-  ResultDart<S, W> mapError<W extends Object>(W Function(F error) fn) {
+  ResultDart<S, W> mapError<W>(W Function(F error) fn) {
     return Success<S, W>(_success);
   }
 
   @override
-  ResultDart<W, F> pure<W extends Object>(W success) {
+  ResultDart<W, F> pure<W>(W success) {
     return map((_) => success);
   }
 
   @override
-  ResultDart<S, W> pureError<W extends Object>(W error) {
+  ResultDart<S, W> pureError<W>(W error) {
     return Success<S, W>(_success);
   }
 
   @override
-  ResultDart<S, R> recover<R extends Object>(
+  ResultDart<S, R> recover<R>(
     ResultDart<S, R> Function(F failure) onFailure,
   ) {
     return Success(_success);
@@ -239,7 +239,7 @@ final class Success<S extends Object, F extends Object> //
   }
 
   @override
-  ResultDart<G, W> mapFold<G extends Object, W extends Object>(
+  ResultDart<G, W> mapFold<G, W>(
     G Function(S success) onSuccess,
     W Function(F failure) onFailure,
   ) {
@@ -250,7 +250,7 @@ final class Success<S extends Object, F extends Object> //
   }
 
   @override
-  ResultDart<G, W> pureFold<G extends Object, W extends Object>(
+  ResultDart<G, W> pureFold<G, W>(
     G success,
     W failure,
   ) {
@@ -266,7 +266,7 @@ final class Success<S extends Object, F extends Object> //
 /// return it when the result of a [ResultDart] is
 /// not the expected value.
 @immutable
-final class Failure<S extends Object, F extends Object> //
+final class Failure<S, F> //
     implements
         ResultDart<S, F> {
   /// Receives the [F] param as
@@ -277,7 +277,7 @@ final class Failure<S extends Object, F extends Object> //
   /// ```dart
   /// Failure.unit() == Failure(unit)
   /// ```
-  static Failure<S, type_unit.Unit> unit<S extends Object>() {
+  static Failure<S, type_unit.Unit> unit<S>() {
     return Failure<S, type_unit.Unit>(type_unit.unit);
   }
 
@@ -311,14 +311,14 @@ final class Failure<S extends Object, F extends Object> //
   S? getOrNull() => null;
 
   @override
-  ResultDart<W, F> flatMap<W extends Object>(
+  ResultDart<W, F> flatMap<W>(
     ResultDart<W, F> Function(S success) fn,
   ) {
     return Failure<W, F>(_failure);
   }
 
   @override
-  ResultDart<S, W> flatMapError<W extends Object>(
+  ResultDart<S, W> flatMapError<W>(
     ResultDart<S, W> Function(F failure) fn,
   ) {
     return fn(_failure);
@@ -331,7 +331,7 @@ final class Failure<S extends Object, F extends Object> //
 
   @override
   S getOrThrow() {
-    throw _failure;
+    throw _failure!;
   }
 
   @override
@@ -343,28 +343,28 @@ final class Failure<S extends Object, F extends Object> //
   S getOrDefault(S defaultValue) => defaultValue;
 
   @override
-  ResultDart<W, F> map<W extends Object>(W Function(S success) fn) {
+  ResultDart<W, F> map<W>(W Function(S success) fn) {
     return Failure<W, F>(_failure);
   }
 
   @override
-  ResultDart<S, W> mapError<W extends Object>(W Function(F failure) fn) {
+  ResultDart<S, W> mapError<W>(W Function(F failure) fn) {
     final newFailure = fn(_failure);
     return Failure(newFailure);
   }
 
   @override
-  ResultDart<W, F> pure<W extends Object>(W success) {
+  ResultDart<W, F> pure<W>(W success) {
     return Failure<W, F>(_failure);
   }
 
   @override
-  ResultDart<S, W> pureError<W extends Object>(W error) {
+  ResultDart<S, W> pureError<W>(W error) {
     return mapError((failure) => error);
   }
 
   @override
-  ResultDart<S, R> recover<R extends Object>(
+  ResultDart<S, R> recover<R>(
     ResultDart<S, R> Function(F failure) onFailure,
   ) {
     return onFailure(_failure);
@@ -385,7 +385,7 @@ final class Failure<S extends Object, F extends Object> //
   }
 
   @override
-  ResultDart<G, W> mapFold<G extends Object, W extends Object>(
+  ResultDart<G, W> mapFold<G, W>(
     G Function(S success) onSuccess,
     W Function(F failure) onFailure,
   ) {
@@ -396,7 +396,7 @@ final class Failure<S extends Object, F extends Object> //
   }
 
   @override
-  ResultDart<G, W> pureFold<G extends Object, W extends Object>(
+  ResultDart<G, W> pureFold<G, W>(
     G success,
     W failure,
   ) {

--- a/lib/src/result_extension.dart
+++ b/lib/src/result_extension.dart
@@ -2,11 +2,11 @@ import '../result_dart.dart';
 
 /// Adds methods for converting any object
 /// into a `Result` type (`Success` or `Failure`).
-extension ResultObjectExtension<W extends Object> on W {
+extension ResultObjectExtension<W> on W {
   /// Convert the object to a `Result` type [Failure].
   ///
   /// Will throw an error if used on a `Result` or `Future` instance.
-  Failure<S, W> toFailure<S extends Object>() {
+  Failure<S, W> toFailure<S>() {
     assert(
       this is! ResultDart,
       'Don`t use the "toError()" method '
@@ -24,7 +24,7 @@ extension ResultObjectExtension<W extends Object> on W {
   /// Convert the object to a `Result` type [Success].
   ///
   /// Will throw an error if used on a `Result` or `Future` instance.
-  Success<W, F> toSuccess<F extends Object>() {
+  Success<W, F> toSuccess<F>() {
     assert(
       this is! ResultDart,
       'Don`t use the "toSuccess()" method '

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,18 +1,18 @@
 import 'package:result_dart/result_dart.dart';
 
 /// A typedef for a `Result` that simplifies the usage of `ResultDart`
-/// with `Exception` as the default failure type.
+/// with `Object` as the default failure type.
 ///
 /// This is used to represent operations that can succeed with a
 /// value of type `S`
-/// or fail with an `Exception`.
-typedef Result<S> = ResultDart<S, Exception>;
+/// or fail with an `Object`.
+typedef Result<S> = ResultDart<S, Object>;
 
 /// A typedef for an asynchronous `Result`, simplifying the usage
 /// of `AsyncResultDart`
-/// with `Exception` as the default failure type.
+/// with `Object` as the default failure type.
 ///
 /// This is used to represent asynchronous operations that can succeed
 /// with a value of type `S`
-/// or fail with an `Exception`.
-typedef AsyncResult<S> = AsyncResultDart<S, Exception>;
+/// or fail with an `Object`.
+typedef AsyncResult<S> = AsyncResultDart<S, Object>;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -6,7 +6,7 @@ import 'package:result_dart/result_dart.dart';
 /// This is used to represent operations that can succeed with a
 /// value of type `S`
 /// or fail with an `Exception`.
-typedef Result<S extends Object> = ResultDart<S, Exception>;
+typedef Result<S> = ResultDart<S, Exception>;
 
 /// A typedef for an asynchronous `Result`, simplifying the usage
 /// of `AsyncResultDart`
@@ -15,4 +15,4 @@ typedef Result<S extends Object> = ResultDart<S, Exception>;
 /// This is used to represent asynchronous operations that can succeed
 /// with a value of type `S`
 /// or fail with an `Exception`.
-typedef AsyncResult<S extends Object> = AsyncResultDart<S, Exception>;
+typedef AsyncResult<S> = AsyncResultDart<S, Exception>;


### PR DESCRIPTION
This PR makes two key improvements to the Result<S, F> type, addressing [issue #13](https://github.com/Flutterando/result_dart/issues/13):

**1. ✅ Allow Nullable Value in Success<S?>**

Previously, the Success constructor required a non-null value, even if T was nullable. This made it impossible to return a Result<S?, F> where the success case might legitimately carry a null (e.g., empty optional data, database fetch miss, etc).

**Now:**

- Success<S?> allows null as a valid success value.
- Keeps the API expressive and avoids awkward workarounds.

**Why this matters:**

- Encourages correct modeling of optional values within the result type.
- Eliminates the need for Option<Result<S, E>> or nullable wrappers around Result.

`Result<String?, Error> result = Success(null); // ✅ Now valid`

**2. 🔁 Change Default Failure Type from Exception to Object**

The original design constrained Failure to use Exception as the default failure type. While that aligns with standard error handling, it’s unnecessarily restrictive.

This PR changes the default to Object, allowing more flexibility, such as:

- Returning a simple String as an error message.
- Using enum-based or code-based error structures.
- Supporting non-Exception types without having to wrap or cast.


`Result<String, String> result = Failure("Something went wrong"); // ✅ No need to throw or wrap`

**Why this matters:**

- Makes the API more ergonomic and expressive for Dart developers.
- Enables functional-style error handling without forcing exception semantics.
- Encourages lighter-weight, clearer domain errors in application code.

**🌟 Summary**

These changes make result_dart more idiomatic, flexible, and aligned with how functional result types are used across languages like Kotlin, Swift, and TypeScript.

- ✅ Supports true S? success values.
- ✅ Removes restriction on failure types.
- 🧪 Fully backward compatible for users of Result<S, Exception> and non-nullable S.